### PR TITLE
make FIPS OID optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ type yubihsmAttestation struct {
 		Capabilities []string `json:"capabilities"`
 		ID           int      `json:"id"`
 		Label        string   `json:"label"`
-		FIPS         bool     `json:"fips"`
+		FIPS         bool     `json:"fips,omitempty"`
 		Algorithm    string   `json:"algorithm"`
 		Size         int      `json:"size"`
 		RSAModulus   *big.Int `json:"modulus,omitempty"`


### PR DESCRIPTION
The FIPS OID was added to attestations in fw v2.4.1. This fix make output compatible with older fw by omitting the fips result.